### PR TITLE
Add new input argument to Model __init__

### DIFF
--- a/pyjags/model.py
+++ b/pyjags/model.py
@@ -193,7 +193,8 @@ class Model:
 
     def __init__(self, code=None, data=None, init=None, chains=4, adapt=1000,
                  file=None, encoding='utf-8', generate_data=True,
-                 progress_bar=True, threads=1, chains_per_thread=1):
+                 progress_bar=True, refresh_seconds=0.5, 
+                 threads=1, chains_per_thread=1):
         """
         Create a JAGS model and run adaptation steps.
 
@@ -249,7 +250,8 @@ class Model:
         load_module('bugs')
         load_module('lecuyer')
 
-        self.progress_bar = progress_bar_factory(progress_bar, refresh_seconds=0.5)
+        self.progress_bar = progress_bar_factory(progress_bar, 
+                                                 refresh_seconds=refresh_seconds)
         self.chains = chains
         self.threads = threads
         self.use_threads = self.threads > 1 and chains_per_thread < self.chains


### PR DESCRIPTION
Add `refresh_seconds` as a new keyword argument to Model.__init__

The `progress_bar` attribute of `Model` is created from the
`progress_bar_factory` that takes an argument `refresh_seconds`. The
value of this argument is hard-coded at 0.5. This creates a frequent
updating of progress, which creates massive amounts of outputs for long
running simulations. It would be preferrable to override this value when
creating a new model.